### PR TITLE
Remove `release` script from `package.json`.

### DIFF
--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -23,9 +23,6 @@ function updatePackageJSON() {
   pkg.devDependencies['release-it'] = '^12.2.1';
   pkg.devDependencies['release-it-lerna-changelog'] = '^1.0.3';
 
-  pkg.scripts = pkg.scripts || {};
-  pkg.scripts.release = 'release-it';
-
   pkg['release-it'] = {
     plugins: {
       'release-it-lerna-changelog': {

--- a/tests/bin-test.js
+++ b/tests/bin-test.js
@@ -11,7 +11,6 @@ QUnit.module('main binary', function(hooks) {
 
   function mergePackageJSON(original, updates) {
     return Object.assign({}, original, updates, {
-      scripts: Object.assign({}, original.scripts, updates.scripts),
       publishConfig: Object.assign({}, original.publishConfig, updates.publishConfig),
       dependencies: Object.assign({}, original.dependencies, updates.dependencies),
       devDependencies: Object.assign({}, original.devDependencies, updates.devDependencies),
@@ -58,9 +57,6 @@ QUnit.module('main binary', function(hooks) {
       devDependencies: {
         'release-it': '^12.2.1',
         'release-it-lerna-changelog': '^1.0.3',
-      },
-      scripts: {
-        release: 'release-it',
       },
       publishConfig: {
         registry: 'https://registry.npmjs.org',


### PR DESCRIPTION
Removing `release` script because of issues when running under `yarn`.  Specifically, `yarn release` (even with `publishConfig` setting the registry) will think it is not authenticated properly. Ultimately, this is just too error prone, so instead we should use `release-it` globally installed instead.

Plays nicely with #8