### PR TITLE
Adding ability to specify filters for changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ Simple npm init / yarn create bin package to add release-it setup used by rwjblu
 
 This will do the following:
 
-* add `release-it` config to the `package.json`
-* install required dependencies,
-* add a `CHANGELOG.md`
-* add a `RELEASE.md`
-* update your repositories labels with my "go to" defaults
+- add `release-it` config to the `package.json`
+- install required dependencies,
+- add a `CHANGELOG.md`
+- add a `RELEASE.md`
+- update your repositories labels with my "go to" defaults
 
 ## Usage
+
+Ensure you have a `GITHUB_ACCESS_TOKEN` environment variable setup. This token needs
+repo access to update labels.
 
 When you want to set up a repo with `release-it`, you can run:
 
@@ -40,6 +43,28 @@ yarn create rwjblue-release-it-setup --labels-only
 
 # in an npm repo
 npm init rwjblue-release-it-setup --labels-only
+```
+
+### Changelog options
+
+If you want to configure your changelog to ignore merge commits, you can use the following option:
+
+```
+# in a yarn repo
+yarn create rwjblue-release-it-setup --no-changelog-merges
+
+# in an npm repo
+npm init rwjblue-release-it-setup --no-changelog-merges
+```
+
+If you want to configure your changelog to ignore dependabot commits, you can use the following option:
+
+```
+# in a yarn repo
+yarn create rwjblue-release-it-setup --no-changelog-dependabot
+
+# in an npm repo
+npm init rwjblue-release-it-setup --no-changelog-dependabot
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -57,16 +57,6 @@ yarn create rwjblue-release-it-setup --no-changelog-merges
 npm init rwjblue-release-it-setup --no-changelog-merges
 ```
 
-If you want to configure your changelog to ignore dependabot commits, you can use the following option:
-
-```
-# in a yarn repo
-yarn create rwjblue-release-it-setup --no-changelog-dependabot
-
-# in an npm repo
-npm init rwjblue-release-it-setup --no-changelog-dependabot
-```
-
 ## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -91,6 +91,12 @@ async function updateLabels() {
     return;
   }
 
+  if (!process.env.GITHUB_ACCESS_TOKEN) {
+    throw new Error(
+      'You must set a GITHUB_ACCESS_TOKEN environment variable. The token must have repo access.'
+    );
+  }
+
   const githubLabelSync = require('github-label-sync');
 
   let accessToken = process.env.GITHUB_ACCESS_TOKEN;

--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -8,6 +8,8 @@ const skipInstall = process.argv.includes('--no-install');
 const skipLabels = process.argv.includes('--no-label-updates');
 const labelsOnly = process.argv.includes('--labels-only');
 const update = process.argv.includes('--update');
+const noMerges = process.argv.includes('--no-changelog-merges');
+const noBots = process.argv.includes('--no-changelog-dependabot');
 
 const DETECT_TRAILING_WHITESPACE = /\s+$/;
 
@@ -39,6 +41,16 @@ function updatePackageJSON() {
   };
   pkg.publishConfig = pkg.publishConfig || {};
   pkg.publishConfig.registry = pkg.publishConfig.registry || 'https://registry.npmjs.org';
+
+  if (noMerges || noBots) {
+    let latestTagExpression = '${latestTag}';
+    let noMergesOption = noMerges ? '--no-merges ' : '';
+    let noBotsOption = noBots ? '--perl-regexp --author="^((?!dependabot-preview).*)$" ' : '';
+
+    pkg[
+      'release-it'
+    ].git.changelog = `git log --pretty=format:'* %s (%h)' ${noMergesOption}${noBotsOption}${latestTagExpression}...HEAD`;
+  }
 
   let sortedPkg = sortPackageJson(pkg);
   let updatedContents = JSON.stringify(sortedPkg, null, 2);

--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -45,11 +45,13 @@ function updatePackageJSON() {
   if (noMerges || noBots) {
     let latestTagExpression = '${latestTag}';
     let noMergesOption = noMerges ? '--no-merges ' : '';
-    let noBotsOption = noBots ? '--perl-regexp --author="^((?!dependabot-preview).*)$" ' : '';
+    // eslint-disable-next-line prettier/prettier, no-useless-escape
+    let noBotsOption = noBots ? '--perl-regexp --author=\"^((?!dependabot-preview).*)$\" ' : '';
 
     pkg[
       'release-it'
-    ].git.changelog = `git log --pretty=format:'* %s (%h)' ${noMergesOption}${noBotsOption}${latestTagExpression}...HEAD`;
+      // eslint-disable-next-line prettier/prettier, no-useless-escape
+    ].git.changelog = `git log --pretty=format:\"* %s (%h)\" ${noMergesOption}${noBotsOption}${latestTagExpression}...HEAD`;
   }
 
   let sortedPkg = sortPackageJson(pkg);

--- a/tests/bin-test.js
+++ b/tests/bin-test.js
@@ -69,6 +69,8 @@ QUnit.module('main binary', function(hooks) {
         },
         git: {
           tagName: 'v${version}',
+          changelog:
+            'git log --pretty=format:"* %s (%h)" --perl-regexp --author="^((?!dependabot-preview).*)$" ${latestTag}...HEAD',
         },
         github: {
           release: true,
@@ -83,80 +85,6 @@ QUnit.module('main binary', function(hooks) {
     let premodificationPackageJSON = JSON.parse(project.toJSON('package.json'));
 
     await execa(BIN_PATH, ['--no-install', '--no-label-updates', '--no-changelog-merges']);
-
-    let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
-    let expected = mergePackageJSON(premodificationPackageJSON, {
-      devDependencies: {
-        'release-it': '^12.2.1',
-        'release-it-lerna-changelog': '^1.0.3',
-      },
-      publishConfig: {
-        registry: 'https://registry.npmjs.org',
-      },
-      'release-it': {
-        plugins: {
-          'release-it-lerna-changelog': {
-            infile: 'CHANGELOG.md',
-          },
-        },
-        git: {
-          tagName: 'v${version}',
-          changelog: 'git log --pretty=format:"* %s (%h)" --no-merges ${latestTag}...HEAD',
-        },
-        github: {
-          release: true,
-        },
-      },
-    });
-
-    assert.deepEqual(pkg, expected);
-  });
-
-  QUnit.test('updates the changelog entry to ignore dependabot commits', async function(assert) {
-    let premodificationPackageJSON = JSON.parse(project.toJSON('package.json'));
-
-    await execa(BIN_PATH, ['--no-install', '--no-label-updates', '--no-changelog-dependabot']);
-
-    let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
-    let expected = mergePackageJSON(premodificationPackageJSON, {
-      devDependencies: {
-        'release-it': '^12.2.1',
-        'release-it-lerna-changelog': '^1.0.3',
-      },
-      publishConfig: {
-        registry: 'https://registry.npmjs.org',
-      },
-      'release-it': {
-        plugins: {
-          'release-it-lerna-changelog': {
-            infile: 'CHANGELOG.md',
-          },
-        },
-        git: {
-          tagName: 'v${version}',
-          changelog:
-            'git log --pretty=format:"* %s (%h)" --perl-regexp --author="^((?!dependabot-preview).*)$" ${latestTag}...HEAD',
-        },
-        github: {
-          release: true,
-        },
-      },
-    });
-
-    assert.deepEqual(pkg, expected);
-  });
-
-  QUnit.test('updates the changelog entry to ignore merge and dependabot commits', async function(
-    assert
-  ) {
-    let premodificationPackageJSON = JSON.parse(project.toJSON('package.json'));
-
-    await execa(BIN_PATH, [
-      '--no-install',
-      '--no-label-updates',
-      '--no-changelog-merges',
-      '--no-changelog-dependabot',
-    ]);
 
     let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
     let expected = mergePackageJSON(premodificationPackageJSON, {

--- a/tests/bin-test.js
+++ b/tests/bin-test.js
@@ -79,6 +79,114 @@ QUnit.module('main binary', function(hooks) {
     assert.deepEqual(pkg, expected);
   });
 
+  QUnit.test('updates the changelog entry to ignore merge commits', async function(assert) {
+    let premodificationPackageJSON = JSON.parse(project.toJSON('package.json'));
+
+    await execa(BIN_PATH, ['--no-install', '--no-label-updates', '--no-changelog-merges']);
+
+    let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
+    let expected = mergePackageJSON(premodificationPackageJSON, {
+      devDependencies: {
+        'release-it': '^12.2.1',
+        'release-it-lerna-changelog': '^1.0.3',
+      },
+      publishConfig: {
+        registry: 'https://registry.npmjs.org',
+      },
+      'release-it': {
+        plugins: {
+          'release-it-lerna-changelog': {
+            infile: 'CHANGELOG.md',
+          },
+        },
+        git: {
+          tagName: 'v${version}',
+          changelog: 'git log --pretty=format:"* %s (%h)" --no-merges ${latestTag}...HEAD',
+        },
+        github: {
+          release: true,
+        },
+      },
+    });
+
+    assert.deepEqual(pkg, expected);
+  });
+
+  QUnit.test('updates the changelog entry to ignore dependabot commits', async function(assert) {
+    let premodificationPackageJSON = JSON.parse(project.toJSON('package.json'));
+
+    await execa(BIN_PATH, ['--no-install', '--no-label-updates', '--no-changelog-dependabot']);
+
+    let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
+    let expected = mergePackageJSON(premodificationPackageJSON, {
+      devDependencies: {
+        'release-it': '^12.2.1',
+        'release-it-lerna-changelog': '^1.0.3',
+      },
+      publishConfig: {
+        registry: 'https://registry.npmjs.org',
+      },
+      'release-it': {
+        plugins: {
+          'release-it-lerna-changelog': {
+            infile: 'CHANGELOG.md',
+          },
+        },
+        git: {
+          tagName: 'v${version}',
+          changelog:
+            'git log --pretty=format:"* %s (%h)" --perl-regexp --author="^((?!dependabot-preview).*)$" ${latestTag}...HEAD',
+        },
+        github: {
+          release: true,
+        },
+      },
+    });
+
+    assert.deepEqual(pkg, expected);
+  });
+
+  QUnit.test('updates the changelog entry to ignore merge and dependabot commits', async function(
+    assert
+  ) {
+    let premodificationPackageJSON = JSON.parse(project.toJSON('package.json'));
+
+    await execa(BIN_PATH, [
+      '--no-install',
+      '--no-label-updates',
+      '--no-changelog-merges',
+      '--no-changelog-dependabot',
+    ]);
+
+    let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
+    let expected = mergePackageJSON(premodificationPackageJSON, {
+      devDependencies: {
+        'release-it': '^12.2.1',
+        'release-it-lerna-changelog': '^1.0.3',
+      },
+      publishConfig: {
+        registry: 'https://registry.npmjs.org',
+      },
+      'release-it': {
+        plugins: {
+          'release-it-lerna-changelog': {
+            infile: 'CHANGELOG.md',
+          },
+        },
+        git: {
+          tagName: 'v${version}',
+          changelog:
+            'git log --pretty=format:"* %s (%h)" --no-merges --perl-regexp --author="^((?!dependabot-preview).*)$" ${latestTag}...HEAD',
+        },
+        github: {
+          release: true,
+        },
+      },
+    });
+
+    assert.deepEqual(pkg, expected);
+  });
+
   QUnit.test('installs dependencies', async function(assert) {
     await execa(BIN_PATH, ['--no-label-updates']);
 


### PR DESCRIPTION
Adds the ability to specify a filter for your changelog to your release-it configuration:
- `--no-changelog-merges` - filters out merge commits

Added default:
- filters out dependabot commits

Also added a section in the README indicating that you need to correctly setup a `GITHUB_ACCESS_TOKEN` env var.