### PR TITLE
only use one environment variable for GitHub access token

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,9 +54,13 @@ yarn install
 npm install
 ```
 
-* And last (but not least 😁) do your release:
+* And last (but not least 😁) do your release. It requires a
+  [GitHub personal access token](https://github.com/settings/tokens) as
+  `$GITHUB_AUTH` environment variable. Only "repo" access is needed; no "admin"
+  or other scopes are required.
 
 ```
+export GITHUB_AUTH="f941e0..."
 release-it
 ```
 

--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -35,6 +35,7 @@ function updatePackageJSON() {
     },
     github: {
       release: true,
+      tokenRef: "GITHUB_AUTH",
     },
   };
   pkg.publishConfig = pkg.publishConfig || {};

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
       "tagName": "v${version}"
     },
     "github": {
-      "release": true
+      "release": true,
+      "tokenRef": "GITHUB_AUTH"
     }
   }
 }


### PR DESCRIPTION
Both release-it and lerna-changelog require a GitHub personal access token. Both read it from an environment variable but by default not using the same name. release-it defaults to `$GITHUB_TOKEN` while lerna-changelog defaults to `$GITHUB_AUTH`. It could only be customized for release-it. Therefore changing it to `$GITHUB_AUTH`.

Also documents that this environment variable is required. It wasn't documented so far at all.

Background information could be found here:
- https://github.com/release-it/release-it/blob/master/docs/github-releases.md
- https://github.com/lerna/lerna-changelog#github-token