### PR TITLE
Ensure label sync uses same token as release-it and lerna-changelog.

### DIFF
--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -79,7 +79,7 @@ async function updateLabels() {
 
   const githubLabelSync = require('github-label-sync');
 
-  let accessToken = process.env.GITHUB_ACCESS_TOKEN;
+  let accessToken = process.env.GITHUB_AUTH;
   let labels = require('../labels');
   let repo = findRepoURL();
 


### PR DESCRIPTION
All of these require the `repo` permissions.