### PR TITLE
Ensure generated devDependencies match those used for testing.

### DIFF
--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -9,6 +9,18 @@ const skipLabels = process.argv.includes('--no-label-updates');
 const labelsOnly = process.argv.includes('--labels-only');
 const update = process.argv.includes('--update');
 
+const RELEASE_IT_VERSION = (() => {
+  let pkg = require('../package');
+
+  return pkg.devDependencies['release-it'];
+})();
+
+const RELEASE_IT_LERNA_CHANGELOG_VERSION = (() => {
+  let pkg = require('../package');
+
+  return pkg.devDependencies['release-it-lerna-changelog'];
+})();
+
 const DETECT_TRAILING_WHITESPACE = /\s+$/;
 
 function updatePackageJSON() {
@@ -21,8 +33,8 @@ function updatePackageJSON() {
   let pkg = JSON.parse(contents);
 
   pkg.devDependencies = pkg.devDependencies || {};
-  pkg.devDependencies['release-it'] = '^12.2.1';
-  pkg.devDependencies['release-it-lerna-changelog'] = '^1.0.3';
+  pkg.devDependencies['release-it'] = RELEASE_IT_VERSION;
+  pkg.devDependencies['release-it-lerna-changelog'] = RELEASE_IT_LERNA_CHANGELOG_VERSION;
 
   pkg['release-it'] = {
     plugins: {

--- a/tests/bin-test.js
+++ b/tests/bin-test.js
@@ -55,8 +55,10 @@ QUnit.module('main binary', function(hooks) {
     let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
     let expected = mergePackageJSON(premodificationPackageJSON, {
       devDependencies: {
-        'release-it': '^12.2.1',
-        'release-it-lerna-changelog': '^1.0.3',
+        'release-it': require('../package').devDependencies['release-it'],
+        'release-it-lerna-changelog': require('../package').devDependencies[
+          'release-it-lerna-changelog'
+        ],
       },
       publishConfig: {
         registry: 'https://registry.npmjs.org',


### PR DESCRIPTION
Now that dependabot is setup in this repo, we need to ensure that we use a minimum version of these devDependencies.