### PR TITLE
Ensure `RELEASE.md` mentions `yarn install` or `npm install` appropriately.

### DIFF
--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -103,11 +103,16 @@ async function updateLabels() {
   });
 }
 
+function isYarn() {
+  return fs.existsSync('yarn.lock');
+}
+
 async function installDependencies() {
   if (labelsOnly || skipInstall) {
     return;
   }
-  if (fs.existsSync('yarn.lock')) {
+
+  if (isYarn()) {
     await execa('yarn');
   } else {
     await execa('npm', ['install']);
@@ -130,9 +135,15 @@ async function main() {
     }
 
     if ((!fs.existsSync('RELEASE.md') || update) && !labelsOnly) {
+      let releaseContents = fs.readFileSync(path.join(__dirname, '..', 'release-template.md'), {
+        encoding: 'utf8',
+      });
+
+      let dependencyInstallReplacementValue = isYarn() ? 'yarn install' : 'npm install';
+
       fs.writeFileSync(
         'RELEASE.md',
-        fs.readFileSync(path.join(__dirname, '..', 'RELEASE.md'), { encoding: 'utf8' }),
+        releaseContents.replace('{{INSTALL_DEPENDENCIES}}', dependencyInstallReplacementValue),
         { encoding: 'utf8' }
       );
     }

--- a/release-template.md
+++ b/release-template.md
@@ -47,7 +47,7 @@ npm install --global release-it
 * Second, ensure that you have installed your projects dependencies:
 
 ```
-yarn install
+{{INSTALL_DEPENDENCIES}}
 ```
 
 * And last (but not least 😁) do your release. It requires a


### PR DESCRIPTION
Prior to this change, the generated `RELEASE.md` would mention both `yarn install` and `npm install`. This was a bit silly since at the time of generation we **know** which they prefer using (if there is a `yarn.lock`, use `yarn install`, otherwise use `npm install).