### PR TITLE
Correctly parse repo information.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "repository": "https://github.com/rwjblue/create-rwjblue-release-it-setup",
   "license": "MIT",
   "author": "Robert Jackson <me@rwjblue.com>",
+  "main": "index.js",
+  "bin": "bin/rwjblue-release-it-setup.js",
   "files": [
     "bin/",
     "index.js",
     "labels.json",
     "release-template.md"
   ],
-  "main": "index.js",
-  "bin": "bin/rwjblue-release-it-setup.js",
   "scripts": {
     "lint:js": "eslint .",
     "release": "release-it",
@@ -22,6 +22,7 @@
   "dependencies": {
     "execa": "^4.0.0",
     "github-label-sync": "^1.4.2",
+    "hosted-git-info": "^3.0.4",
     "sort-package-json": "^1.40.0"
   },
   "devDependencies": {

--- a/tests/bin-test.js
+++ b/tests/bin-test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const Project = require('fixturify-project');
+const BinScript = require('../bin/rwjblue-release-it-setup');
 const execa = require('execa');
 
 const BIN_PATH = require.resolve('../bin/rwjblue-release-it-setup');
@@ -160,5 +161,21 @@ QUnit.module('main binary', function(hooks) {
         );
       });
     });
+  });
+});
+
+QUnit.module('unit', function() {
+  QUnit.module('findRepoURL', function() {
+    function confirmResult(pkg, expected) {
+      QUnit.test(`${expected} from ${JSON.stringify(pkg)}`, function(assert) {
+        assert.strictEqual(BinScript.findRepoURL(pkg), expected);
+      });
+    }
+
+    confirmResult({ repository: 'https://github.com/rwjblue/foo' }, 'rwjblue/foo');
+    confirmResult({ repository: 'https://github.com/rwjblue/foo.git' }, 'rwjblue/foo');
+    confirmResult({ repository: 'https://github.com/rwjblue/foo.js.git' }, 'rwjblue/foo.js');
+    confirmResult({ repository: 'ssh://github.com:rwjblue/foo.git' }, 'rwjblue/foo');
+    confirmResult({ repository: 'ssh://github.com:rwjblue/foo.js.git' }, 'rwjblue/foo.js');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,6 +1614,13 @@ highlight.js@^9.6.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
   integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
 
+hosted-git-info@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.4.tgz#be4973eb1fd2737b11c9c7c19380739bb249f60d"
+  integrity sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==
+  dependencies:
+    lru-cache "^5.1.1"
+
 http-cache-semantics@^4.0.0, http-cache-semantics@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"


### PR DESCRIPTION
This leverages the [hosted-git-info](https://github.com/npm/hosted-git-info) package, which is used by the `npm` CLI for parsing these exact strings. This is **much** better than manually writing a RegExp.

Fixes https://github.com/rwjblue/create-rwjblue-release-it-setup/issues/31