### PR TITLE
Avoid deleting existing GitHub labels when adding new ones.

### DIFF
--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -97,6 +97,7 @@ async function updateLabels(pkg) {
     accessToken,
     repo,
     labels,
+    allowAddedLabels: true,
   });
 }
 


### PR DESCRIPTION
Prior to this, running `npx create-rwjblue-releas-it-setup` would delete any labels that did not match the set listed in `./labels.json`. This is pretty poor behavior.

This commit ensures that the labels are additive only.