### PR TITLE
Avoid downgrading release-it / release-it-lerna-changelog.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "execa": "^4.0.0",
     "github-label-sync": "^1.4.2",
     "hosted-git-info": "^3.0.4",
+    "semver": "^7.1.3",
     "sort-package-json": "^1.40.0"
   },
   "devDependencies": {

--- a/tests/bin-test.js
+++ b/tests/bin-test.js
@@ -7,6 +7,10 @@ const execa = require('execa');
 const BIN_PATH = require.resolve('../bin/rwjblue-release-it-setup');
 const ROOT = process.cwd();
 
+function exec(args) {
+  return execa(process.execPath, ['--unhandled-rejections=strict', BIN_PATH, ...args]);
+}
+
 QUnit.module('main binary', function(hooks) {
   let project;
 
@@ -31,7 +35,7 @@ QUnit.module('main binary', function(hooks) {
   QUnit.test('adds CHANGELOG.md file', async function(assert) {
     assert.notOk(fs.existsSync('CHANGELOG.md'), 'precond - CHANGELOG.md is not present');
 
-    await execa(BIN_PATH, ['--no-install', '--no-label-updates']);
+    await exec(['--no-install', '--no-label-updates']);
 
     assert.ok(fs.existsSync('CHANGELOG.md'), 'CHANGELOG.md is present');
   });
@@ -39,7 +43,7 @@ QUnit.module('main binary', function(hooks) {
   QUnit.skip('removes prefix from existing CHANGELOG.md', async function(assert) {
     project.files['CHANGELOG.md'] = `# master\n\n# v1.2.0\n* Foo bar`;
 
-    await execa(BIN_PATH, ['--no-install', '--no-label-updates']);
+    await exec(['--no-install', '--no-label-updates']);
 
     assert.strictEqual(
       fs.readFileSync('CHANGELOG.md', { encoding: 'utf8' }),
@@ -108,7 +112,7 @@ QUnit.module('main binary', function(hooks) {
     QUnit.test('adds RELEASE.md to repo when no yarn.lock exists', async function(assert) {
       assert.notOk(fs.existsSync('RELEASE.md'), 'precond - RELEASE.md is not present');
 
-      await execa(BIN_PATH, ['--no-install', '--no-label-updates']);
+      await exec(['--no-install', '--no-label-updates']);
 
       assert.strictEqual(
         fs.readFileSync('RELEASE.md', { encoding: 'utf8' }),
@@ -122,7 +126,7 @@ QUnit.module('main binary', function(hooks) {
 
       assert.notOk(fs.existsSync('RELEASE.md'), 'precond - RELEASE.md is not present');
 
-      await execa(BIN_PATH, ['--no-install', '--no-label-updates']);
+      await exec(['--no-install', '--no-label-updates']);
 
       assert.strictEqual(
         fs.readFileSync('RELEASE.md', { encoding: 'utf8' }),
@@ -133,14 +137,14 @@ QUnit.module('main binary', function(hooks) {
 
     QUnit.module('--update', function(hooks) {
       hooks.beforeEach(async function() {
-        await execa(BIN_PATH, ['--no-install', '--no-label-updates']);
+        await exec(['--no-install', '--no-label-updates']);
       });
 
       QUnit.test('updates RELEASE.md when yarn.lock exists', async function(assert) {
         fs.writeFileSync('yarn.lock', '', { encoding: 'utf-8' });
         fs.writeFileSync('RELEASE.md', 'lololol', 'utf8');
 
-        await execa(BIN_PATH, ['--no-install', '--no-label-updates', '--update']);
+        await exec(['--no-install', '--no-label-updates', '--update']);
 
         assert.strictEqual(
           fs.readFileSync('RELEASE.md', { encoding: 'utf8' }),
@@ -152,7 +156,7 @@ QUnit.module('main binary', function(hooks) {
       QUnit.test('updates RELEASE.md when no yarn.lock exists', async function(assert) {
         fs.writeFileSync('RELEASE.md', 'lololol', 'utf8');
 
-        await execa(BIN_PATH, ['--no-install', '--no-label-updates', '--update']);
+        await exec(['--no-install', '--no-label-updates', '--update']);
 
         assert.strictEqual(
           fs.readFileSync('RELEASE.md', { encoding: 'utf8' }),

--- a/tests/bin-test.js
+++ b/tests/bin-test.js
@@ -52,50 +52,135 @@ QUnit.module('main binary', function(hooks) {
     );
   });
 
-  QUnit.test('updates the package.json', async function(assert) {
-    let premodificationPackageJSON = JSON.parse(project.toJSON('package.json'));
+  QUnit.module('package.json', function() {
+    QUnit.test('adds release-it configuration and devDependencies to package.json', async function(
+      assert
+    ) {
+      let premodificationPackageJSON = JSON.parse(project.toJSON('package.json'));
 
-    await execa(BIN_PATH, ['--no-install', '--no-label-updates']);
+      await exec(['--no-install', '--no-label-updates']);
 
-    let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
-    let expected = mergePackageJSON(premodificationPackageJSON, {
-      devDependencies: {
-        'release-it': require('../package').devDependencies['release-it'],
-        'release-it-lerna-changelog': require('../package').devDependencies[
-          'release-it-lerna-changelog'
-        ],
-      },
-      publishConfig: {
-        registry: 'https://registry.npmjs.org',
-      },
-      'release-it': {
-        plugins: {
-          'release-it-lerna-changelog': {
-            infile: 'CHANGELOG.md',
-            launchEditor: true,
+      let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
+      let expected = mergePackageJSON(premodificationPackageJSON, {
+        devDependencies: {
+          'release-it': require('../package').devDependencies['release-it'],
+          'release-it-lerna-changelog': require('../package').devDependencies[
+            'release-it-lerna-changelog'
+          ],
+        },
+        publishConfig: {
+          registry: 'https://registry.npmjs.org',
+        },
+        'release-it': {
+          plugins: {
+            'release-it-lerna-changelog': {
+              infile: 'CHANGELOG.md',
+              launchEditor: true,
+            },
+          },
+          git: {
+            tagName: 'v${version}',
+          },
+          github: {
+            release: true,
+            tokenRef: 'GITHUB_AUTH',
           },
         },
-        git: {
-          tagName: 'v${version}',
-        },
-        github: {
-          release: true,
-          tokenRef: 'GITHUB_AUTH',
-        },
-      },
+      });
+
+      assert.deepEqual(pkg, expected);
     });
 
-    assert.deepEqual(pkg, expected);
-  });
+    QUnit.test('does not update devDependencies if release-it range is greater', async function(
+      assert
+    ) {
+      project.addDevDependency('release-it', '^13.2.0');
+      project.writeSync();
 
-  QUnit.test('installs dependencies', async function(assert) {
-    await execa(BIN_PATH, ['--no-label-updates']);
+      let premodificationPackageJSON = JSON.parse(project.toJSON('package.json'));
 
-    assert.ok(fs.existsSync('node_modules/release-it'), 'release-it installed');
-    assert.ok(
-      fs.existsSync('node_modules/release-it-lerna-changelog'),
-      'release-it-lerna-changelog installed'
+      await exec(['--no-install', '--no-label-updates']);
+
+      let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
+      let expected = mergePackageJSON(premodificationPackageJSON, {
+        devDependencies: {
+          'release-it': '^13.2.0',
+          'release-it-lerna-changelog': require('../package').devDependencies[
+            'release-it-lerna-changelog'
+          ],
+        },
+        publishConfig: {
+          registry: 'https://registry.npmjs.org',
+        },
+        'release-it': {
+          plugins: {
+            'release-it-lerna-changelog': {
+              infile: 'CHANGELOG.md',
+              launchEditor: true,
+            },
+          },
+          git: {
+            tagName: 'v${version}',
+          },
+          github: {
+            release: true,
+            tokenRef: 'GITHUB_AUTH',
+          },
+        },
+      });
+
+      assert.deepEqual(pkg, expected);
+    });
+
+    QUnit.test(
+      'does not update devDependencies if release-it-lerna-changelog range is greater',
+      async function(assert) {
+        project.addDevDependency('release-it-lerna-changelog', '^3.0.0');
+        project.writeSync();
+
+        let premodificationPackageJSON = JSON.parse(project.toJSON('package.json'));
+
+        await exec(['--no-install', '--no-label-updates']);
+
+        let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
+        let expected = mergePackageJSON(premodificationPackageJSON, {
+          devDependencies: {
+            'release-it': require('../package').devDependencies['release-it'],
+            'release-it-lerna-changelog': '^3.0.0',
+          },
+          publishConfig: {
+            registry: 'https://registry.npmjs.org',
+          },
+          'release-it': {
+            plugins: {
+              'release-it-lerna-changelog': {
+                infile: 'CHANGELOG.md',
+                launchEditor: true,
+              },
+            },
+            git: {
+              tagName: 'v${version}',
+            },
+            github: {
+              release: true,
+              tokenRef: 'GITHUB_AUTH',
+            },
+          },
+        });
+
+        assert.deepEqual(pkg, expected);
+      }
     );
+
+    QUnit.test('installs dependencies', async function(assert) {
+      await exec(['--no-label-updates']);
+
+      assert.ok(fs.existsSync('node_modules/release-it'), 'release-it installed');
+      assert.ok(
+        fs.existsSync('node_modules/release-it-lerna-changelog'),
+        'release-it-lerna-changelog installed'
+      );
+    });
   });
 
   QUnit.module('RELEASE.md', function() {
@@ -180,6 +265,19 @@ QUnit.module('unit', function() {
       QUnit.test(`${source} -> ${expected}`, function(assert) {
         assert.strictEqual(BinScript.findRepoURL({ repository: source }), expected);
         assert.strictEqual(BinScript.findRepoURL({ repository: { url: source } }), expected);
+      });
+    });
+  });
+
+  QUnit.module('getDependencyRange', function() {
+    [
+      { theirs: '1.0.0', ours: '^2.0.0', expected: '^2.0.0' },
+      { theirs: '^3.0.0', ours: '^2.0.0', expected: '^3.0.0' },
+      { theirs: 'github:foo/bar', ours: '^2.0.0', expected: 'github:foo/bar' },
+      { theirs: 'foo/bar', ours: '^2.0.0', expected: 'foo/bar' },
+    ].forEach(({ theirs, ours, expected }) => {
+      QUnit.test(`${theirs},${ours} -> ${expected}`, function(assert) {
+        assert.strictEqual(BinScript.getDependencyRange(theirs, ours), expected);
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3047,7 +3047,7 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-semver@7.1.3:
+semver@7.1.3, semver@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==


### PR DESCRIPTION
When the project that we are runnign against has a newer version of `release-it` or `release-it-lerna-changelog` we would always downgrade their specified version to whatever we have specified in our own `devDependencies`.

This is pretty bad behavior, and has been fixed. Now if the project defines a dev dependency that is _newer_ than our range, we use it directly.