### PR TITLE
Attempt to populate `repository` info from `.git/config`

### DIFF
--- a/__tests__/bin-test.js
+++ b/__tests__/bin-test.js
@@ -42,6 +42,23 @@ describe('main binary', function () {
 
   describe('package.json', function () {
     it('adds repository info when discoverable from `.git/config`', async function () {
+      project.files['.git'] = {
+        config: `
+[core]
+  repositoryformatversion = 0
+  filemode = true
+  bare = false
+  logallrefupdates = true
+  ignorecase = true
+  precomposeunicode = true
+
+[remote "origin"]
+  url = git@github.com:someuser/some-repo.git
+  fetch = +refs/heads/*:refs/remotes/origin/*`,
+      };
+
+      project.writeSync();
+
       await exec(['--no-install', '--no-label-updates']);
 
       let pkg = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }));
@@ -72,6 +89,10 @@ describe('main binary', function () {
                 "launchEditor": true,
               },
             },
+          },
+          "repository": Object {
+            "type": "git",
+            "url": "git@github.com:someuser/some-repo.git",
           },
           "version": "0.1.0",
         }
@@ -425,6 +446,7 @@ describe('unit', function () {
       ${'git@github.com:rwjblue/foo.js.git'}     | ${'rwjblue/foo.js'}
       ${'rwjblue/foo'}                           | ${'rwjblue/foo'}
       ${'rwjblue/foo.js'}                        | ${'rwjblue/foo.js'}
+      ${''}                                      | ${undefined}
     `('$source -> $expected', ({ source, expected }) => {
       expect(BinScript.findRepoURL({ repository: source })).toBe(expected);
       expect(BinScript.findRepoURL({ repository: { url: source } })).toBe(expected);

--- a/__tests__/bin-test.js
+++ b/__tests__/bin-test.js
@@ -391,12 +391,15 @@ describe('main binary', function () {
 describe('unit', function () {
   describe('findRepoURL', function () {
     it.each`
-      input                                      | expected
+      source                                     | expected
       ${'https://github.com/rwjblue/foo'}        | ${'rwjblue/foo'}
       ${'https://github.com/rwjblue/foo.git'}    | ${'rwjblue/foo'}
       ${'https://github.com/rwjblue/foo.js.git'} | ${'rwjblue/foo.js'}
       ${'git@github.com:rwjblue/foo.git'}        | ${'rwjblue/foo'}
       ${'git@github.com:rwjblue/foo.js.git'}     | ${'rwjblue/foo.js'}
+      ${'git@github.com:rwjblue/foo.js.git'}     | ${'rwjblue/foo.js'}
+      ${'rwjblue/foo'}                           | ${'rwjblue/foo'}
+      ${'rwjblue/foo.js'}                        | ${'rwjblue/foo.js'}
     `('$source -> $expected', ({ source, expected }) => {
       expect(BinScript.findRepoURL({ repository: source })).toBe(expected);
       expect(BinScript.findRepoURL({ repository: { url: source } })).toBe(expected);

--- a/__tests__/bin-test.js
+++ b/__tests__/bin-test.js
@@ -385,17 +385,16 @@ describe('main binary', function () {
 
 describe('unit', function () {
   describe('findRepoURL', function () {
-    [
-      ['https://github.com/rwjblue/foo', 'rwjblue/foo'],
-      ['https://github.com/rwjblue/foo.git', 'rwjblue/foo'],
-      ['https://github.com/rwjblue/foo.js.git', 'rwjblue/foo.js'],
-      ['git@github.com:rwjblue/foo.git', 'rwjblue/foo'],
-      ['git@github.com:rwjblue/foo.js.git', 'rwjblue/foo.js'],
-    ].forEach(([source, expected]) => {
-      it(`${source} -> ${expected}`, function () {
-        expect(BinScript.findRepoURL({ repository: source })).toBe(expected);
-        expect(BinScript.findRepoURL({ repository: { url: source } })).toBe(expected);
-      });
+    it.each`
+      input                                      | expected
+      ${'https://github.com/rwjblue/foo'}        | ${'rwjblue/foo'}
+      ${'https://github.com/rwjblue/foo.git'}    | ${'rwjblue/foo'}
+      ${'https://github.com/rwjblue/foo.js.git'} | ${'rwjblue/foo.js'}
+      ${'git@github.com:rwjblue/foo.git'}        | ${'rwjblue/foo'}
+      ${'git@github.com:rwjblue/foo.js.git'}     | ${'rwjblue/foo.js'}
+    `('$source -> $expected', ({ source, expected }) => {
+      expect(BinScript.findRepoURL({ repository: source })).toBe(expected);
+      expect(BinScript.findRepoURL({ repository: { url: source } })).toBe(expected);
     });
   });
 

--- a/__tests__/bin-test.js
+++ b/__tests__/bin-test.js
@@ -313,12 +313,17 @@ describe('main binary', function () {
       expect(pkg).toEqual(expected);
     });
 
-    it('installs dependencies', async function () {
-      await exec(['--no-label-updates']);
+    // skip this test when running locally, it is pretty slow and unlikely to _actually_ matter
+    (process.env.CI ? it : it.skip)(
+      'installs dependencies',
+      async function () {
+        await exec(['--no-label-updates']);
 
-      expect(fs.existsSync('node_modules/release-it')).toBeTruthy();
-      expect(fs.existsSync('node_modules/release-it-lerna-changelog')).toBeTruthy();
-    }, 15000);
+        expect(fs.existsSync('node_modules/release-it')).toBeTruthy();
+        expect(fs.existsSync('node_modules/release-it-lerna-changelog')).toBeTruthy();
+      },
+      15000
+    );
   });
 
   describe('RELEASE.md', function () {

--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -161,6 +161,11 @@ async function updateLabels(pkg) {
   let labels = require('../labels');
   let repo = findRepoURL(pkg);
 
+  // no repository setup, bail
+  if (!repo) {
+    return;
+  }
+
   await githubLabelSync({
     accessToken,
     repo,

--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const util = require('util');
 const execa = require('execa');
 const sortPackageJson = require('sort-package-json');
 const getRepoInfoFromURL = require('hosted-git-info').fromUrl;
@@ -10,6 +11,7 @@ const skipInstall = process.argv.includes('--no-install');
 const skipLabels = process.argv.includes('--no-label-updates');
 const labelsOnly = process.argv.includes('--labels-only');
 const update = process.argv.includes('--update');
+const gitconfig = util.promisify(require('gitconfiglocal'));
 
 const RELEASE_IT_VERSION = (() => {
   let pkg = require('../package');
@@ -59,7 +61,7 @@ function getDependencyRange(theirs, ours) {
   return ours;
 }
 
-function updatePackageJSON() {
+async function updatePackageJSON() {
   let contents = fs.readFileSync('package.json', { encoding: 'utf8' });
   let trailingWhitespace = DETECT_TRAILING_WHITESPACE.exec(contents);
   let pkg = JSON.parse(contents);
@@ -67,6 +69,24 @@ function updatePackageJSON() {
 
   if (labelsOnly) {
     return pkg;
+  }
+
+  if (!findRepoURL(pkg)) {
+    try {
+      let config = await gitconfig(process.cwd());
+      let originRemoteUrl = config.remote && config.remote.origin && config.remote.origin.url;
+
+      if (originRemoteUrl) {
+        pkg.repository = {
+          type: 'git',
+          url: originRemoteUrl,
+        };
+      }
+    } catch (error) {
+      if (!error.message.includes('no gitconfig to be found')) {
+        throw error;
+      }
+    }
   }
 
   pkg.devDependencies = pkg.devDependencies || {};
@@ -220,7 +240,7 @@ async function main() {
       );
     }
 
-    let pkg = updatePackageJSON();
+    let pkg = await updatePackageJSON();
 
     await installDependencies();
 

--- a/bin/rwjblue-release-it-setup.js
+++ b/bin/rwjblue-release-it-setup.js
@@ -141,7 +141,8 @@ function findRepoURL(pkg) {
     return;
   }
 
-  const url = pkg.repository.url || pkg.repository;
+  // see https://docs.npmjs.com/configuring-npm/package-json#repository for valid formats
+  const url = typeof pkg.repository === 'string' ? pkg.repository : pkg.repository.url;
   const repoInfo = getRepoInfoFromURL(url);
   if (repoInfo === undefined || repoInfo === null || repoInfo.type !== 'github') {
     return;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "execa": "^4.0.1",
+    "gitconfiglocal": "^2.1.0",
     "github-label-sync": "^1.6.0",
     "hosted-git-info": "^3.0.4",
     "semver": "^7.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2393,6 +2393,13 @@ git-url-parse@11.1.2:
   dependencies:
     git-up "^4.0.0"
 
+gitconfiglocal@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/gitconfiglocal/-/gitconfiglocal-2.1.0.tgz#07c28685c55cc5338b27b5acbcfe34aeb92e43d1"
+  integrity sha512-qoerOEliJn3z+Zyn1HW2F6eoYJqKwS6MgC9cztTLUB/xLWX8gD/6T60pKn4+t/d6tP7JlybI7Z3z+I572CR/Vg==
+  dependencies:
+    ini "^1.3.2"
+
 github-label-sync@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/github-label-sync/-/github-label-sync-1.6.0.tgz#6cf15a9f663980b977dc8332f534f89aca6a64ca"
@@ -2784,7 +2791,7 @@ inherits@2, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==


### PR DESCRIPTION
* Attempt to populate the `package.json`s `repository` field from `.git/config` if present
* Avoid attempting to run `github-label-sync` when no repository is found

Fixes #14
Fixes #81