### PR TITLE
docs(README): explain `GITHUB_AUTH` env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ This will do the following:
 ### Prerequisites
 
 1. Obtain a [GitHub personal access token][generate-token].
-2. Make sure the [token is available as the `GITHUB_AUTH` environment variable][export-token].
+2. Make sure the token is available as the `GITHUB_AUTH` environment variable.
   For instance:
   ```bash
   export GITHUB_AUTH=abc123def456
   ```
 
 [generate-token]: https://github.com/settings/tokens/new?scopes=repo&description=GITHUB_AUTH+env+variable
-[export-token]: https://github.com/release-it/release-it/blob/master/docs/environment-variables.md
 
 ### Freshly Configuring a Repo
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ This will do the following:
 
 ## Usage
 
+### Prerequisites
+
+1. Obtain a [GitHub personal access token][generate-token].
+2. Make sure the [token is available as the `GITHUB_AUTH` environment variable][export-token].
+  For instance:
+  ```bash
+  export GITHUB_AUTH=abc123def456
+  ```
+
+[generate-token]: https://github.com/settings/tokens/new?scopes=repo&description=GITHUB_AUTH+env+variable
+[export-token]: https://github.com/release-it/release-it/blob/master/docs/environment-variables.md
+
+### Freshly Configuring a Repo
+
 When you want to set up a repo with `release-it`, you can run:
 
 ```
@@ -22,6 +36,8 @@ yarn create rwjblue-release-it-setup
 npm init rwjblue-release-it-setup
 ```
 
+### Updating an Already Configured Repo
+
 If you'd like to update an existing repo to use the latest and greatest setup, you can run:
 
 ```
@@ -31,6 +47,8 @@ yarn create rwjblue-release-it-setup --update
 # in an npm repo
 npm init rwjblue-release-it-setup --update
 ```
+
+### Only Sync Labels
 
 If you'd like to run only the label sync, you can do that with:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,9 +56,11 @@ yarn install
 ```
 
 * And last (but not least 😁) do your release. It requires a
-  [GitHub personal access token](https://github.com/settings/tokens) as
+  [GitHub personal access token][generate-token] as
   `$GITHUB_AUTH` environment variable. Only "repo" access is needed; no "admin"
   or other scopes are required.
+
+[generate-token]: https://github.com/settings/tokens/new?scopes=repo&description=GITHUB_AUTH+env+variable
 
 ```
 export GITHUB_AUTH="f941e0..."


### PR DESCRIPTION
I tried running this tool, but received this cryptic 404 error:

```
❯ yarn create rwjblue-release-it-setup
yarn create v1.22.4
[1/4] 🔍  Resolving packages...
warning create-rwjblue-release-it-setup > github-label-sync > octonode > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Installed "create-rwjblue-release-it-setup@2.9.0" with binaries:
      - create-rwjblue-release-it-setup
[HttpError: Not Found] {
  message: 'Not Found',
  statusCode: 404,
  headers: {
    date: 'Tue, 16 Jun 2020 15:32:32 GMT',
    'content-type': 'application/json; charset=utf-8',
    'content-length': '107',
    connection: 'close',
    server: 'GitHub.com',
    status: '404 Not Found',
    'x-ratelimit-limit': '60',
    'x-ratelimit-remaining': '59',
    'x-ratelimit-reset': '1592325152',
    'x-github-media-type': 'github.v3; param=symmetra-preview; format=json',
    'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset',
    'access-control-allow-origin': '*',
    'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
    'x-frame-options': 'deny',
    'x-content-type-options': 'nosniff',
    'x-xss-protection': '1; mode=block',
    'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin',
    'content-security-policy': "default-src 'none'",
    vary: 'Accept-Encoding, Accept, X-Requested-With',
    'x-github-request-id': 'E5B8:36872:50BA98:62C6D6:5EE8E610'
  },
  body: {
    message: 'Not Found',
    documentation_url: 'https://developer.github.com/v3/issues/labels/#update-a-label'
  },
  method: 'PATCH',
  endpoint: '/repos/ClarkSource/eslint-config/labels/good%20first%20issue'
}
(node:35691) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:35691) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
✨  Done in 15.25s.
```

I read through the source code and realized that it implicitly expects the `GITHUB_AUTH` env var to be set. After setting the variable, it worked! ✨ 

To save others from running into this as well, I updated the docs to explain this prerequisite setup.