### PR TITLE
Update generated RELEASE.md guidance.

### DIFF
--- a/release-template.md
+++ b/release-template.md
@@ -30,34 +30,29 @@ When reviewing merged PR's the labels to be used are:
 
 Once the prep work is completed, the actual release is straight forward:
 
-* First ensure that you have `release-it` installed globally, generally done by
-  using one of the following commands:
-
-```
-# using https://volta.sh
-volta install release-it
-
-# using Yarn
-yarn global add release-it
-
-# using npm
-npm install --global release-it
-```
-
-* Second, ensure that you have installed your projects dependencies:
+* First, ensure that you have installed your projects dependencies:
 
 ```
 {{INSTALL_DEPENDENCIES}}
 ```
 
-* And last (but not least 😁) do your release. It requires a
-  [GitHub personal access token](https://github.com/settings/tokens) as
-  `$GITHUB_AUTH` environment variable. Only "repo" access is needed; no "admin"
-  or other scopes are required.
+* Second, ensure that you have obtained a
+  [GitHub personal access token][generate-token] with the `repo` scope (no
+  other permissions are needed). Make sure the token is available as the
+  `GITHUB_AUTH` environment variable.
+
+  For instance:
+
+  ```bash
+  export GITHUB_AUTH=abc123def456
+  ```
+
+[generate-token]: https://github.com/settings/tokens/new?scopes=repo&description=GITHUB_AUTH+env+variable
+
+* And last (but not least 😁) do your release.
 
 ```
-export GITHUB_AUTH="f941e0..."
-release-it
+npx release-it
 ```
 
 [release-it](https://github.com/release-it/release-it/) manages the actual


### PR DESCRIPTION
* Remove reference to installing `release-it` globally (swap to using `npx release-it` as the actual release step)
* Add more info on the GITHUB_AUTH token (and customize the link for generating the token)

Fixes #105