### PR TITLE
Increase timeout for end-to-end acceptance test.

### DIFF
--- a/__tests__/bin-test.js
+++ b/__tests__/bin-test.js
@@ -463,7 +463,7 @@ describe('main binary', function () {
         expect(fs.existsSync('node_modules/release-it')).toBeTruthy();
         expect(fs.existsSync('node_modules/release-it-lerna-changelog')).toBeTruthy();
       },
-      15000
+      60000
     );
   });
 


### PR DESCRIPTION
Sometimes `yarn install` / `npm ci` takes longer than 15 seconds, this increases the timeout to 60 seconds. It is still possible for this to fail, but much less often.