### PR TITLE
use release-it version of project

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,9 +30,9 @@ Once the prep work is completed, the actual release is straight forward:
 
 * First, ensure that you have installed your projects dependencies:
 
-```sh
-yarn install
-```
+  ```sh
+  yarn install
+  ```
 
 * Second, ensure that you have obtained a
   [GitHub personal access token][generate-token] with the `repo` scope (no
@@ -49,9 +49,9 @@ yarn install
 
 * And last (but not least 😁) do your release.
 
-```sh
-npx release-it
-```
+  ```sh
+  yarn run release-it
+  ```
 
 [release-it](https://github.com/release-it/release-it/) manages the actual
 release process. It will prompt you to choose the version number after which


### PR DESCRIPTION
Using `npx` to run `release-it` has several trade-offs:

1. `release-it` needs to be downloaded and installed first.
2. It uses the latest version of `release-it` instead of the version installed in the project.

I think we should recommend using the version of `release-it` already installed in the project. The documentation already assumes that yarn is used as package manager. Following that assumption it would be `yarn run release-it`.

Additionally I fix the indentation of the code blocks to make them shown as being part of the item in the list.